### PR TITLE
Linking failed in VS for class SymbolPlaceHolder missing SWALLOW_EXPORT

### DIFF
--- a/swallow/semantics/Symbol.h
+++ b/swallow/semantics/Symbol.h
@@ -73,7 +73,7 @@ public:
 protected:
     int flags;
 };
-class SymbolPlaceHolder : public Symbol
+class SWALLOW_EXPORT SymbolPlaceHolder : public Symbol
 {
 public:
     enum Role


### PR DESCRIPTION
Linking failed in VS for class SymbolPlaceHolder missing SWALLOW_EXPORT
