### PR TITLE
Eliminate warnings/errors found by PVS-Studio analyzer

### DIFF
--- a/swallow/src/common/SwallowUtils.cpp
+++ b/swallow/src/common/SwallowUtils.cpp
@@ -39,6 +39,7 @@
 #include <cstdlib>
 #if defined(_WIN32) || defined(_WIN64)
 #include <Windows.h>
+#include <io.h>
 #else
 #include <dirent.h>
 #include <unistd.h>
@@ -53,7 +54,7 @@ using namespace std;
 bool SwallowUtils::fileExists(const char* path)
 {
 #ifdef _MSC_VER
-    return _access(path, 0 )) != -1;
+    return _access(path, 0 ) != -1;
 #else
     return access(path, F_OK) != -1;
 #endif

--- a/swallow/src/parser/Parser.cpp
+++ b/swallow/src/parser/Parser.cpp
@@ -58,7 +58,7 @@ void Parser::setSourceFile(const SourceFilePtr& sourceFile)
 }
 void Parser::setFunctionName(const wchar_t* function)
 {
-    this->functionName = functionName;
+    this->functionName = function;
 }
 int Parser::getFlags() const
 {

--- a/swallow/src/semantics/SemanticAnalyzer_FunctionCall.cpp
+++ b/swallow/src/semantics/SemanticAnalyzer_FunctionCall.cpp
@@ -256,7 +256,7 @@ float SemanticAnalyzer::calculateFitScore(bool mutatingSelf, SymbolPtr& func, co
             if(!constraintSatisfied)
             {
                 if(supressErrors)
-                    return false;
+                    return -1;
                 error(arguments, Errors::E_TYPE_DOES_NOT_CONFORM_TO_PROTOCOL_2_, argType->getName(), expectedType->getName());
                 abort();
             }

--- a/swallow/src/semantics/Type.cpp
+++ b/swallow/src/semantics/Type.cpp
@@ -762,7 +762,7 @@ int Type::compare(const TypePtr &lhs, const TypePtr &rhs)
         case Tuple:
         {
             if (lhs->elementTypes.size() != rhs->elementTypes.size())
-                return false;
+                return -1;
             auto iter = lhs->elementTypes.begin(), iter2 = rhs->elementTypes.begin();
             for (; iter != lhs->elementTypes.end() && iter2 != rhs->elementTypes.end(); iter++, iter2++)
             {
@@ -775,7 +775,7 @@ int Type::compare(const TypePtr &lhs, const TypePtr &rhs)
         case MetaType:
             return compare(lhs->innerType, rhs->innerType);
         case Module:
-            return true;
+            return 1;
         case Function:
         {
             auto iter = lhs->parameters.begin(), iter2 = rhs->parameters.begin();

--- a/swallow/src/tokenizer/Tokenizer.cpp
+++ b/swallow/src/tokenizer/Tokenizer.cpp
@@ -363,7 +363,7 @@ OperatorType::T Tokenizer::calculateOperatorType(const wchar_t* begin, const wch
     OperatorType::T ret = OperatorType::_;
     bool whiteLeft = hasWhiteLeft(begin);
     bool whiteRight = hasWhiteRight(end);
-    if((whiteRight && whiteLeft) || (!whiteLeft && !whiteRight))
+    if(whiteRight == whiteLeft)
     {
         //If an operator has whitespace around both sides or around neither side, it is treated as a binary operator. As an example, the + operator in a+b and a + b is treated as a binary operator.
         ret = OperatorType::InfixBinary;

--- a/swallow/tests/parser/TestClass.cpp
+++ b/swallow/tests/parser/TestClass.cpp
@@ -927,7 +927,7 @@ TEST(TestClass, testWeakReference)
     ASSERT_EQ(4, s->numDeclarations());
 
     ASSERT_NOT_NULL(vars = std::dynamic_pointer_cast<ValueBindings>(s->getDeclaration(2)));
-    ASSERT_TRUE(vars->getModifiers() && DeclarationModifiers::Weak);
+    ASSERT_TRUE(vars->getModifiers() & DeclarationModifiers::Weak);
 
 }
 
@@ -951,7 +951,7 @@ TEST(TestClass, testUnownedReference)
     ASSERT_EQ(4, s->numDeclarations());
 
     ASSERT_NOT_NULL(let = std::dynamic_pointer_cast<ValueBindings>(s->getDeclaration(1)));
-    ASSERT_TRUE(let->getModifiers() && DeclarationModifiers::Unowned);
+    ASSERT_TRUE(let->getModifiers() & DeclarationModifiers::Unowned);
 
 }
 


### PR DESCRIPTION
Hello!
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A list of bugs, found using PVS-Studio analyzer:

[V570 ](https://www.viva64.com/en/w/v570/)The 'this->functionName' variable is assigned to itself. parser.cpp 61
[V768](https://www.viva64.com/en/w/v768/) The enumeration constant 'Weak' is used as a variable of a Boolean-type. testclass.cpp 930
[V768 ](https://www.viva64.com/en/w/v768/)The enumeration constant 'Unowned' is used as a variable of a Boolean-type. testclass.cpp 954
[V728 ](https://www.viva64.com/en/w/v728/)An excessive check can be simplified. The '(A && B) || (!A && !B)' expression is equivalent to the 'bool(A) == bool(B)' expression. tokenizer.cpp 366
[V601 ](https://www.viva64.com/en/w/v601/)The bool type is implicitly cast to the float type. semanticanalyzer_functioncall.cpp 259

There are actually way more warnings were found but they are not so interesting.